### PR TITLE
Add the script source directory to the ruby path for 1.9+.

### DIFF
--- a/seal-convert
+++ b/seal-convert
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # -*- ruby -*-
 
+$: << File.dirname(__FILE__)
+
 require 'yaml'
 require 'fileutils'
 require 'src/albumconverter'

--- a/seal-tex
+++ b/seal-tex
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # -*- ruby -*-
 
+$: << File.dirname(__FILE__)
+
 class Seal
 
   def initialize( options )


### PR DESCRIPTION
Starting with Ruby 1.9, the current path isn't added to the `LOAD_PATH` by default, causing the `seal-convert` and `seal-tex` scripts to fail. This ought to fix them up.
