### PR TITLE
Newer YAML parsers like psych are having problems with these quotes.

### DIFF
--- a/data/albumtitles.yaml
+++ b/data/albumtitles.yaml
@@ -240,7 +240,7 @@
 - |
   \scalebox{1.5}{\Huge ``Love And Theft''}
 
-- ``Love And Theft''
+- "``Love And Theft''"
 - Recorded Spring 2001 --- Released September 11, 2001
 42_bs5: 
 - |


### PR DESCRIPTION
The psych YAML parser doesn't like the quotes surrounding this particular line and ends up bombing out with a parse error.
